### PR TITLE
Call nanocomponent constructor

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ module.exports = CacheElement
 
 function CacheElement (render) {
   if (!(this instanceof CacheElement)) return new CacheElement(render)
+  Nanocomponent.call(this)
   this._handleRender = render
 }
 CacheElement.prototype = Object.create(Nanocomponent.prototype)


### PR DESCRIPTION
The constructor isn't currently called, which means the element is never cached because `_hasWindow` is always undefined. See https://github.com/yoshuawuyts/nanocomponent/blob/master/index.js#L7 and https://glitch.com/edit/#!/good-crack